### PR TITLE
Use community WebView fork

### DIFF
--- a/App.js
+++ b/App.js
@@ -8,16 +8,8 @@
 
 // External dependencies
 import React from 'react';
-import {
-  Alert,
-  BackHandler,
-  Linking,
-  Platform,
-  StatusBar,
-  StyleSheet,
-  View,
-  WebView,
-} from 'react-native';
+import { Alert, BackHandler, Linking, Platform, StatusBar, StyleSheet, View } from 'react-native';
+import { WebView } from 'react-native-webview';
 import Constants from 'expo-constants';
 import { Notifications } from 'expo';
 
@@ -276,12 +268,12 @@ export default class App extends React.Component {
     console.log('handleLoadEnd');
     this.webView.injectJavaScript(
       //   This is needed because we want to subscribe notifications only
-      //   if user is authenticated window.postMessage accepts one
-      //   argument, data, which will be available on the event object,
-      //   event.nativeEvent.data. data must be a string.
+      //   if user is authenticated window.ReactNativeWebView.postMessage
+      //   accepts one argument, data, which will be available on the event
+      //   object, event.nativeEvent.data. data must be a string.
       `
-        if (window.user && window.user._id && typeof window.postMessage === 'function') {
-          window.postMessage('{ "action": "authenticated" }');
+        if (window.user && window.user._id && typeof window.ReactNativeWebView.postMessage === 'function') {
+          window.ReactNativeWebView.postMessage('{ "action": "authenticated" }');
         }
         ${this.appInfoJavaScript}
       `

--- a/package-lock.json
+++ b/package-lock.json
@@ -3155,6 +3155,17 @@
         "unimodules-permissions-interface": "~2.0.1",
         "unimodules-sensors-interface": "~2.0.1",
         "uuid-js": "^0.7.5"
+      },
+      "dependencies": {
+        "react-native-webview": {
+          "version": "5.8.1",
+          "resolved": "https://registry.npmjs.org/react-native-webview/-/react-native-webview-5.8.1.tgz",
+          "integrity": "sha512-b6pSvmjoiWtcz6YspggW02X+BRXJWuquHwkh37BRx1NMW1iwMZA31SnFQvTpPzWYYIb9WF/mRsy2nGtt9C6NIg==",
+          "requires": {
+            "escape-string-regexp": "1.0.5",
+            "invariant": "2.2.4"
+          }
+        }
       }
     },
     "expo-ads-admob": {
@@ -6639,9 +6650,9 @@
       }
     },
     "react-native-webview": {
-      "version": "5.8.1",
-      "resolved": "https://registry.npmjs.org/react-native-webview/-/react-native-webview-5.8.1.tgz",
-      "integrity": "sha512-b6pSvmjoiWtcz6YspggW02X+BRXJWuquHwkh37BRx1NMW1iwMZA31SnFQvTpPzWYYIb9WF/mRsy2nGtt9C6NIg==",
+      "version": "5.8.2",
+      "resolved": "https://registry.npmjs.org/react-native-webview/-/react-native-webview-5.8.2.tgz",
+      "integrity": "sha512-WvB5vH3xaxwXbk0RFGDIkM+MEeMfrfkhXdgYW1qj/xUuioeH5lduCpR+sID8+OR35zx+pBuamQ9jSlRGuREJrw==",
       "requires": {
         "escape-string-regexp": "1.0.5",
         "invariant": "2.2.4"

--- a/package.json
+++ b/package.json
@@ -20,7 +20,8 @@
     "react": "16.8.3",
     "react-dom": "^16.8.6",
     "react-native": "https://github.com/expo/react-native/archive/sdk-33.0.0.tar.gz",
-    "react-native-web": "^0.11.4"
+    "react-native-web": "^0.11.4",
+    "react-native-webview": "^5.8.2"
   },
   "devDependencies": {
     "babel-preset-expo": "^5.1.1",


### PR DESCRIPTION
Went to [React Native's WebView docs](https://facebook.github.io/react-native/docs/webview.html) and was greeted by this warning:
![webview-warning](https://user-images.githubusercontent.com/3090888/63891135-cd8ff180-c9e4-11e9-9869-c5823b272da7.png)

This PR replaces the core's `WebView` with [the community one](https://github.com/react-native-community/react-native-webview).
For more info, check [the Slimmening proposal](https://github.com/react-native-community/discussions-and-proposals/issues/6) and [the relevant PR](https://github.com/react-native-community/discussions-and-proposals/pull/3).

I've run the app and played around a bit, and things still seem to work as normal.